### PR TITLE
Adds support for the generic OTLP endpoint and insecure exporter options

### DIFF
--- a/launcher/config_test.go
+++ b/launcher/config_test.go
@@ -330,7 +330,7 @@ func TestEnvironmentVariables(t *testing.T) {
 	expected := &Config{
 		ExporterEndpoint:                "generic-url",
 		ExporterEndpointInsecure:        false,
-		TracesExporterEndpoint:          "satellite-url",
+		TracesExporterEndpoint:          "traces-url",
 		TracesExporterEndpointInsecure:  true,
 		TracesEnabled:                   true,
 		ServiceName:                     "test-service-name",
@@ -362,7 +362,7 @@ func TestConfigurationOverrides(t *testing.T) {
 		WithServiceVersion("override-service-version"),
 		WithExporterEndpoint("override-generic-url"),
 		WithExporterInsecure(false),
-		WithSpanExporterEndpoint("override-satellite-url"),
+		WithSpanExporterEndpoint("override-traces-url"),
 		WithSpanExporterInsecure(false),
 		WithMetricExporterEndpoint("override-metrics-url"),
 		WithMetricExporterInsecure(false),
@@ -389,7 +389,7 @@ func TestConfigurationOverrides(t *testing.T) {
 		ServiceVersion:                  "override-service-version",
 		ExporterEndpoint:                "override-generic-url",
 		ExporterEndpointInsecure:        false,
-		TracesExporterEndpoint:          "override-satellite-url",
+		TracesExporterEndpoint:          "override-traces-url",
 		TracesExporterEndpointInsecure:  false,
 		TracesEnabled:                   true,
 		MetricsExporterEndpoint:         "override-metrics-url",
@@ -649,7 +649,7 @@ func setenv(key string, value string) {
 
 func setEnvironment() {
 	setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "generic-url")
-	setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "satellite-url")
+	setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "traces-url")
 	setenv("OTEL_EXPORTER_OTLP_TRACES_INSECURE", "true")
 	setenv("OTEL_SERVICE_NAME", "test-service-name")
 	setenv("OTEL_SERVICE_VERSION", "test-service-version")

--- a/launcher/config_test.go
+++ b/launcher/config_test.go
@@ -288,12 +288,12 @@ func TestDefaultConfig(t *testing.T) {
 	expected := &Config{
 		ExporterEndpoint:                "localhost:4317",
 		ExporterEndpointInsecure:        false,
-		TracesExporterEndpoint:          "localhost:4317",
+		TracesExporterEndpoint:          "",
 		TracesExporterEndpointInsecure:  false,
 		TracesEnabled:                   true,
 		ServiceName:                     "",
 		ServiceVersion:                  "unknown",
-		MetricsExporterEndpoint:         "localhost:4317",
+		MetricsExporterEndpoint:         "",
 		MetricsExporterEndpointInsecure: false,
 		MetricsEnabled:                  true,
 		MetricsReportingPeriod:          "30s",
@@ -329,7 +329,7 @@ func TestEnvironmentVariables(t *testing.T) {
 
 	expected := &Config{
 		ExporterEndpoint:                "generic-url",
-		ExporterEndpointInsecure:        false,
+		ExporterEndpointInsecure:        true,
 		TracesExporterEndpoint:          "traces-url",
 		TracesExporterEndpointInsecure:  true,
 		TracesEnabled:                   true,
@@ -642,6 +642,65 @@ func TestConfigWithResourceAttributes(t *testing.T) {
 	defer shutdown()
 }
 
+func TestEmptyTracesEndpointFallsBackToGenericEndpoint(t *testing.T) {
+	unsetEnvironment()
+	testCases := []struct {
+		name            string
+		config          *Config
+		tracesEndpoint  string
+		tracesInsecure  bool
+		metricsEndpoint string
+		metricsInsecure bool
+	}{
+		{
+			name:            "defaults",
+			config:          newConfig(),
+			tracesEndpoint:  "localhost:4317",
+			tracesInsecure:  false,
+			metricsEndpoint: "localhost:4317",
+			metricsInsecure: false,
+		},
+		{
+			name: "set generic endpoint / insecure",
+			config: newConfig(
+				WithExporterEndpoint("generic-url"),
+				WithExporterInsecure(true),
+			),
+			tracesEndpoint:  "generic-url",
+			tracesInsecure:  true,
+			metricsEndpoint: "generic-url",
+			metricsInsecure: true,
+		},
+		{
+			name: "set specific endpoint / insecure",
+			config: newConfig(
+				WithExporterEndpoint("generic-url"),
+				WithExporterInsecure(false),
+				WithSpanExporterEndpoint("traces-url"),
+				WithSpanExporterInsecure(true),
+				WithMetricExporterEndpoint("metrics-url"),
+				WithMetricExporterInsecure(true),
+			),
+			tracesEndpoint:  "traces-url",
+			tracesInsecure:  true,
+			metricsEndpoint: "metrics-url",
+			metricsInsecure: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tracesEndpoint, tracesInsecure := tc.config.getTracesEndpoint()
+			assert.Equal(t, tc.tracesEndpoint, tracesEndpoint)
+			assert.Equal(t, tc.tracesInsecure, tracesInsecure)
+
+			metricsEndpoint, metricsInsecure := tc.config.getMetricsEndpoint()
+			assert.Equal(t, tc.metricsEndpoint, metricsEndpoint)
+			assert.Equal(t, tc.metricsInsecure, metricsInsecure)
+		})
+	}
+}
+
 // setenv is to stop the linter from complaining.
 func setenv(key string, value string) {
 	_ = os.Setenv(key, value)
@@ -649,6 +708,7 @@ func setenv(key string, value string) {
 
 func setEnvironment() {
 	setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "generic-url")
+	setenv("OTEL_EXPORTER_OTLP_INSECURE", "true")
 	setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "traces-url")
 	setenv("OTEL_EXPORTER_OTLP_TRACES_INSECURE", "true")
 	setenv("OTEL_SERVICE_NAME", "test-service-name")
@@ -666,6 +726,8 @@ func unsetEnvironment() {
 	vars := []string{
 		"OTEL_SERVICE_NAME",
 		"OTEL_SERVICE_VERSION",
+		"OTEL_EXPORTER_OTLP_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_INSECURE",
 		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
 		"OTEL_EXPORTER_OTLP_TRACES_INSECURE",
 		"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",

--- a/launcher/config_test.go
+++ b/launcher/config_test.go
@@ -286,6 +286,8 @@ func TestDefaultConfig(t *testing.T) {
 	}
 
 	expected := &Config{
+		ExporterEndpoint:                "localhost:4317",
+		ExporterEndpointInsecure:        false,
 		TracesExporterEndpoint:          "localhost:4317",
 		TracesExporterEndpointInsecure:  false,
 		TracesEnabled:                   true,
@@ -326,6 +328,8 @@ func TestEnvironmentVariables(t *testing.T) {
 	}
 
 	expected := &Config{
+		ExporterEndpoint:                "generic-url",
+		ExporterEndpointInsecure:        false,
 		TracesExporterEndpoint:          "satellite-url",
 		TracesExporterEndpointInsecure:  true,
 		TracesEnabled:                   true,
@@ -356,6 +360,8 @@ func TestConfigurationOverrides(t *testing.T) {
 	config := newConfig(
 		WithServiceName("override-service-name"),
 		WithServiceVersion("override-service-version"),
+		WithExporterEndpoint("override-generic-url"),
+		WithExporterInsecure(false),
 		WithSpanExporterEndpoint("override-satellite-url"),
 		WithSpanExporterInsecure(false),
 		WithMetricExporterEndpoint("override-metrics-url"),
@@ -381,6 +387,8 @@ func TestConfigurationOverrides(t *testing.T) {
 	expected := &Config{
 		ServiceName:                     "override-service-name",
 		ServiceVersion:                  "override-service-version",
+		ExporterEndpoint:                "override-generic-url",
+		ExporterEndpointInsecure:        false,
 		TracesExporterEndpoint:          "override-satellite-url",
 		TracesExporterEndpointInsecure:  false,
 		TracesEnabled:                   true,
@@ -640,6 +648,7 @@ func setenv(key string, value string) {
 }
 
 func setEnvironment() {
+	setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "generic-url")
 	setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "satellite-url")
 	setenv("OTEL_EXPORTER_OTLP_TRACES_INSECURE", "true")
 	setenv("OTEL_SERVICE_NAME", "test-service-name")


### PR DESCRIPTION
Adds support for reading and using the generic OTLP exporter endpoint and insecure options. They can be used independently or in combination with the specific traces and metrics endpoints.

- Closes #421