### PR TITLE
Vary default port by protocol

### DIFF
--- a/launcher/README.md
+++ b/launcher/README.md
@@ -10,7 +10,7 @@ go get github.com/opentelemetry-go-contrib/otel-launcher-go/launcher
 
 ## Configure
 
-Minimal setup - by default will send all telemetry to `localhost:4317`
+Minimal setup - by default will send all telemetry via GRPC to `localhost:4317`
 
 ```go
 import "github.com/opentelemetry-go-contrib/otel-launcher-go/launcher"
@@ -41,7 +41,7 @@ func main() {
 ## Configuration Options
 
 | Config Option               | Env Variable                        | Required | Default              |
-| --------------------------  | ----------------------------------- | -------- | -------------------- |
+| --------------------------- | ----------------------------------- | -------- | -------------------- |
 | WithServiceName             | OTEL_SERVICE_NAME                   | y        | -                    |
 | WithServiceVersion          | OTEL_SERVICE_VERSION                | n        | -                    |
 | WithHeaders                 | OTEL_EXPORTER_OTLP_HEADERS          | n        | {}                   |

--- a/launcher/config_test.go
+++ b/launcher/config_test.go
@@ -286,7 +286,7 @@ func TestDefaultConfig(t *testing.T) {
 	}
 
 	expected := &Config{
-		ExporterEndpoint:                "localhost:4317",
+		ExporterEndpoint:                "localhost:DEFAULTPORT",
 		ExporterEndpointInsecure:        false,
 		TracesExporterEndpoint:          "",
 		TracesExporterEndpointInsecure:  false,
@@ -655,9 +655,9 @@ func TestEmptyTracesEndpointFallsBackToGenericEndpoint(t *testing.T) {
 		{
 			name:            "defaults",
 			config:          newConfig(),
-			tracesEndpoint:  "localhost:4317",
+			tracesEndpoint:  "localhost:DEFAULTPORT",
 			tracesInsecure:  false,
-			metricsEndpoint: "localhost:4317",
+			metricsEndpoint: "localhost:DEFAULTPORT",
 			metricsInsecure: false,
 		},
 		{


### PR DESCRIPTION
Adds a default port that varies based on the specified protocol.

Along the way, I noticed that I had failed to use the correct type for protocol in config and it was affecting this PR, so I fixed that.

1. User specifies `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=host`, but does not include a port. This change appends the default port value.
2. User specifies `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf`, but does not specify anything about endpoints OR metrics. Metrics still defaults to grpc and 4317.

Why this is still a draft:
- [ ] Case 1 still not implemented
- [ ] Add test for case 1
- [ ] Add test for case 2
- [ ] Add test for default case behavior

Fixes #418.
