### PR TITLE
Add support for configuring a custom sampler

### DIFF
--- a/launcher/config.go
+++ b/launcher/config.go
@@ -215,6 +215,13 @@ func WithMetricsExporterProtocol(protocol Protocol) Option {
 	}
 }
 
+// WithSampler configures the Sampler to use when processing trace spans.
+func WithSampler(sampler trace.Sampler) Option {
+	return func(c *Config) {
+		c.Sampler = sampler
+	}
+}
+
 // Logger is an interface for a logger that can be passed to WithLogger.
 type Logger interface {
 	Fatalf(format string, v ...interface{})
@@ -278,6 +285,7 @@ type Config struct {
 	Headers                         map[string]string
 	ResourceAttributes              map[string]string
 	SpanProcessors                  []trace.SpanProcessor
+	Sampler                         trace.Sampler
 	Resource                        *resource.Resource
 	Logger                          Logger
 	ShutdownFunctions               []func(c *Config) error
@@ -290,6 +298,7 @@ func newConfig(opts ...Option) *Config {
 		ResourceAttributes: map[string]string{},
 		Logger:             defLogger,
 		errorHandler:       &defaultHandler{logger: defLogger},
+		Sampler:            trace.AlwaysSample(),
 	}
 	envError := envconfig.Process(context.Background(), c)
 	if envError != nil {

--- a/launcher/config_test.go
+++ b/launcher/config_test.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/sdk/resource"
+	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 	collectormetrics "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	collectortrace "go.opentelemetry.io/proto/otlp/collector/trace/v1"
@@ -699,6 +700,25 @@ func TestEmptyTracesEndpointFallsBackToGenericEndpoint(t *testing.T) {
 			assert.Equal(t, tc.metricsInsecure, metricsInsecure)
 		})
 	}
+}
+
+func TestCanConfigureCustomSampler(t *testing.T) {
+	sampler := &testSampler{}
+	config := newConfig(
+		WithSampler(sampler),
+	)
+
+	assert.Same(t, config.Sampler, sampler)
+}
+
+type testSampler struct{}
+
+func (ts *testSampler) ShouldSample(parameters trace.SamplingParameters) trace.SamplingResult {
+	return trace.SamplingResult{}
+}
+
+func (ts *testSampler) Description() string {
+	return "testSampler"
 }
 
 // setenv is to stop the linter from complaining.

--- a/launcher/pipelines/common.go
+++ b/launcher/pipelines/common.go
@@ -39,6 +39,7 @@ type PipelineConfig struct {
 	ReportingPeriod string
 	Propagators     []string
 	SpanProcessors  []trace.SpanProcessor
+	Sampler         trace.Sampler
 }
 
 // PipelineSetupFunc defines the interface for a Pipeline Setup function.

--- a/launcher/pipelines/trace.go
+++ b/launcher/pipelines/trace.go
@@ -37,7 +37,7 @@ import (
 func NewTracePipeline(c PipelineConfig) (func() error, error) {
 	opts := []trace.TracerProviderOption{
 		trace.WithResource(c.Resource),
-		trace.WithSampler(trace.AlwaysSample()),
+		trace.WithSampler(c.Sampler),
 	}
 	for _, sp := range c.SpanProcessors {
 		opts = append(opts, trace.WithSpanProcessor(sp))


### PR DESCRIPTION
Adds support for being able to configure a custom sampler that is used when configuring the traces pipeline. The current default is to always use an AlwaysOn sampler.

This PR extends both the launcher Config PipelineConfig to take a trace.Sampler that is passed to it by the launcher config. The default is still to use the AlwaysOn sampler.