### PR TITLE
Separate traces and metrics headers

### DIFF
--- a/launcher/config.go
+++ b/launcher/config.go
@@ -483,7 +483,7 @@ func (c *Config) getMetricsEndpoint() (string, bool) {
 	return ensurePort(c.MetricsExporterEndpoint, port), c.MetricsExporterEndpointInsecure
 }
 
-// getTracesExporterHeaders combines and returns both generic and traces headers
+// getTracesExporterHeaders combines and returns both generic and traces headers.
 func getTracesExporterHeaders(c *Config) map[string]string {
 	headers := map[string]string{}
 	for key, value := range c.Headers {
@@ -513,7 +513,7 @@ func setupTracing(c *Config) (func() error, error) {
 	})
 }
 
-// getTracesHeaders combines and returns both generic and traces headers
+// getMetricsExporterHeaders combines and returns both generic and traces headers.
 func getMetricsExporterHeaders(c *Config) map[string]string {
 	// copy custom generic and metrics headers
 	headers := map[string]string{}

--- a/launcher/config_test.go
+++ b/launcher/config_test.go
@@ -772,11 +772,11 @@ func TestGenericAndSignalHeadersAreCombined(t *testing.T) {
 		assert.Equal(t, map[string]string{
 			"lnchr-headers": "true",
 			"lnchr-traces":  "true",
-		}, getTracesExporterHeaders(c))
+		}, c.getTracesHeaders())
 		assert.Equal(t, map[string]string{
 			"lnchr-headers": "true",
 			"lnchr-metrics": "true",
-		}, getMetricsExporterHeaders(c))
+		}, c.getMetricsHeaders())
 		return nil
 	}
 

--- a/launcher/config_test.go
+++ b/launcher/config_test.go
@@ -303,6 +303,8 @@ func TestDefaultConfig(t *testing.T) {
 		MetricsReportingPeriod:          "30s",
 		LogLevel:                        "info",
 		Headers:                         map[string]string{},
+		TracesHeaders:                   map[string]string{},
+		MetricsHeaders:                  map[string]string{},
 		ResourceAttributes:              map[string]string{},
 		Propagators:                     []string{"tracecontext", "baggage"},
 		Resource:                        resource.NewWithAttributes(semconv.SchemaURL, attributes...),
@@ -346,6 +348,8 @@ func TestEnvironmentVariables(t *testing.T) {
 		MetricsReportingPeriod:          "30s",
 		LogLevel:                        "debug",
 		Headers:                         map[string]string{},
+		TracesHeaders:                   map[string]string{},
+		MetricsHeaders:                  map[string]string{},
 		ResourceAttributes:              map[string]string{},
 		ResourceAttributesFromEnv:       "service.name=test-service-name-b",
 		Propagators:                     []string{"b3", "w3c"},
@@ -403,6 +407,8 @@ func TestConfigurationOverrides(t *testing.T) {
 		MetricsReportingPeriod:          "30s",
 		LogLevel:                        "info",
 		Headers:                         map[string]string{},
+		TracesHeaders:                   map[string]string{},
+		MetricsHeaders:                  map[string]string{},
 		ResourceAttributes:              map[string]string{},
 		ResourceAttributesFromEnv:       "service.name=test-service-name-b",
 		Propagators:                     []string{"b3"},
@@ -759,6 +765,33 @@ func TestCanConfigureCustomSampler(t *testing.T) {
 	)
 
 	assert.Same(t, config.Sampler, sampler)
+}
+
+func TestGenericAndSignalHeadersAreCombined(t *testing.T) {
+	ValidateConfig = func(c *Config) error {
+		assert.Equal(t, map[string]string{
+			"lnchr-headers": "true",
+			"lnchr-traces":  "true",
+		}, getTracesExporterHeaders(c))
+		assert.Equal(t, map[string]string{
+			"lnchr-headers": "true",
+			"lnchr-metrics": "true",
+		}, getMetricsExporterHeaders(c))
+		return nil
+	}
+
+	_, err := ConfigureOpenTelemetry(
+		WithHeaders(map[string]string{
+			"lnchr-headers": "true",
+		}),
+		WithTracesHeaders(map[string]string{
+			"lnchr-traces": "true",
+		}),
+		WithMetricsHeaders(map[string]string{
+			"lnchr-metrics": "true",
+		}),
+	)
+	assert.Nil(t, err)
 }
 
 type testSampler struct{}


### PR DESCRIPTION
Separates traces and metrics headers so each exporter can have a different set. Generic and signal specific headers are combined when passing to the pipeline to create the exporter.

- Closes #646 

This allows for traces and metrics exporters to have different sets of headers, which is useful especially when sending telemetry to different endpoints.