### PR TITLE
Update defaultLogger with loglevel after applying options

### DIFF
--- a/launcher/config.go
+++ b/launcher/config.go
@@ -271,6 +271,7 @@ func WithLogger(logger Logger) Option {
 }
 
 type defaultLogger struct {
+	logLevel string
 }
 
 func (l *defaultLogger) Fatalf(format string, v ...interface{}) {
@@ -279,10 +280,12 @@ func (l *defaultLogger) Fatalf(format string, v ...interface{}) {
 }
 
 func (l *defaultLogger) Debugf(format string, v ...interface{}) {
-	log.Printf(format, v...)
+	if l.logLevel == "debug" {
+		log.Printf(format, v...)
+	}
 }
 
-var defLogger Logger = &defaultLogger{}
+var defLogger Logger = &defaultLogger{logLevel: "info"}
 
 type defaultHandler struct {
 	logger Logger
@@ -350,6 +353,11 @@ func newConfig(opts ...Option) *Config {
 	// apply vendor options then user options
 	for _, opt := range append(vendorOpts, opts...) {
 		opt(c)
+	}
+
+	// If using defaultLogger, update it's LogLevel to configured level
+	if l, ok := c.Logger.(*defaultLogger); ok {
+		l.logLevel = c.LogLevel
 	}
 
 	c.Resource = newResource(c)

--- a/launcher/config_test.go
+++ b/launcher/config_test.go
@@ -794,6 +794,24 @@ func TestGenericAndSignalHeadersAreCombined(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestDefaultLoggerLogLevelIsInfo(t *testing.T) {
+	c := newConfig()
+	if l, ok := c.Logger.(*defaultLogger); ok {
+		assert.Equal(t, "info", l.logLevel)
+	} else {
+		assert.Fail(t, "default logger is not a defaultLogger")
+	}
+}
+
+func TestDefaultLoggerUsesConfiguredLogLevel(t *testing.T) {
+	c := newConfig(WithLogLevel("fatal"))
+	if l, ok := c.Logger.(*defaultLogger); ok {
+		assert.Equal(t, "fatal", l.logLevel)
+	} else {
+		assert.Fail(t, "default logger is not a defaultLogger")
+	}
+}
+
 type testSampler struct{}
 
 func (ts *testSampler) ShouldSample(parameters trace.SamplingParameters) trace.SamplingResult {

--- a/launcher/config_test.go
+++ b/launcher/config_test.go
@@ -794,15 +794,6 @@ func TestGenericAndSignalHeadersAreCombined(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestDefaultLoggerLogLevelIsInfo(t *testing.T) {
-	c := newConfig()
-	if l, ok := c.Logger.(*defaultLogger); ok {
-		assert.Equal(t, "info", l.logLevel)
-	} else {
-		assert.Fail(t, "default logger is not a defaultLogger")
-	}
-}
-
 type testSampler struct{}
 
 func (ts *testSampler) ShouldSample(parameters trace.SamplingParameters) trace.SamplingResult {

--- a/launcher/config_test.go
+++ b/launcher/config_test.go
@@ -803,15 +803,6 @@ func TestDefaultLoggerLogLevelIsInfo(t *testing.T) {
 	}
 }
 
-func TestDefaultLoggerUsesConfiguredLogLevel(t *testing.T) {
-	c := newConfig(WithLogLevel("fatal"))
-	if l, ok := c.Logger.(*defaultLogger); ok {
-		assert.Equal(t, "fatal", l.logLevel)
-	} else {
-		assert.Fail(t, "default logger is not a defaultLogger")
-	}
-}
-
 type testSampler struct{}
 
 func (ts *testSampler) ShouldSample(parameters trace.SamplingParameters) trace.SamplingResult {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
When using the `defaultLogger` type, we should only write using the `debugf` func when the configured LogLevel is `debug`. However, currently any call to `debugf` will write to stdout because it doesn't know about a log level.

- Helps address https://github.com/honeycombio/honeycomb-opentelemetry-go/issues/78

## Short description of the changes
- Add LogLevel to defaultLogger struct
- Set defaultLogger instance to use log level of `info`
- If using defaultLogger after applying options, update the instance's log level to match the configured value
- Added unit tests to verify behaviour

## How to verify that this has the expected result
- Default log level should be `info`
- Updating the LogLevel and not replacing the logger updates the defaultLogger's level
- Debug messages are only written to stdout when using the defaultLogger and log level is `debug`