### PR TITLE
fix: missing sampler pass-through

### DIFF
--- a/launcher/config.go
+++ b/launcher/config.go
@@ -531,6 +531,7 @@ func setupTracing(c *Config) (func() error, error) {
 		Resource:       c.Resource,
 		Propagators:    c.Propagators,
 		SpanProcessors: c.SpanProcessors,
+		Sampler:        c.Sampler,
 	})
 }
 


### PR DESCRIPTION
Discovered when testing example services with sampling configuration, and the honeycomb distro was not honoring SAMPLE_RATE env var.